### PR TITLE
Add post-link to put machine name in a file

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,10 @@ pkgs_dirs:
 
 CONDARC
 
-
-mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+$PYTHON -m pip install -vv --no-deps .
+
+mkdir -p "$PREFIX"/bin
+POST_LINK="$PREFIX"/bin/.mache-post-link.sh
+cp "$SRC_DIR"/conda/post-link.sh "$POST_LINK"
+chmod +x "$POST_LINK"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: 31e6b773ffa526f29c1917064ca58c04418b97ef7629bf3fb840cf95094599b0
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1
   noarch: python
   entry_points:
     - mache = mache.__main__:main

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+machine=$("${PREFIX}/bin/python" -c "from mache import discover_machine; print(discover_machine(quiet=True))")
+if [[ "${machine}" != "None" ]]; then
+  mkdir -p "${PREFIX}/share/mache"
+  echo "${machine}" > "${PREFIX}/share/mache/machine.txt"
+fi


### PR DESCRIPTION
If the machine name cannot be discovered at runtime from the host name or an environment variable, get it from this file created at install time.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
