### PR TITLE
[DEV] Add post-link to put machine name in a file

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+$PYTHON -m pip install -vv --no-deps .
+
+mkdir -p "$PREFIX"/bin
+POST_LINK="$PREFIX"/bin/.mache-post-link.sh
+cp "$SRC_DIR"/conda/post-link.sh "$POST_LINK"
+chmod +x "$POST_LINK"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: 9eb5ed790147c348c78bd753119e21a9e4c8088e5ec501f82a8db751f8f93e8a
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1
   noarch: python
   entry_points:
     - mache = mache.__main__:main

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+machine=$("${PREFIX}/bin/python" -c "from mache import discover_machine; print(discover_machine(quiet=True))")
+if [[ "${machine}" != "None" ]]; then
+  mkdir -p "${PREFIX}/share/mache"
+  echo "${machine}" > "${PREFIX}/share/mache/machine.txt"
+fi


### PR DESCRIPTION
If the machine name cannot be discovered at runtime from the host name or an environment variable, get it from this file created at install time.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
